### PR TITLE
Add details about multiple clusters and Tiller

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ Here are some suggestions to mitigate against potential risks during migration:
   3. Migrate Helm v2 releases.
   4. When happy that Helm v3 is managing Helm v2 data as expected, then clean up Helm v2 data.
 
+*Note:*
+A Helm v2 client: 
+- can manage 1 to many Kubernetes clusters
+- can connect to 1 to many Tiller instances for  a cluster 
+This means that you have to cognisant of this when migrating as releases are deployed into clusters by Tiller and
+its namespace. You have to therefore be aware of migrating for each cluster and each Tiller instance that is managed
+by the Helm v2 client instance. Cleanup should only be run once all migration for a Helm v2 client is complete.
+
+## Prerequisite
+
+- Helm v2 client installed on a system which manages releases on one to many clusters
+- Helm v3 client installed on the same system
+
 ## Usage
 
 ### Migrate Helm v2 configuration
@@ -126,7 +139,7 @@ $ helm 2to3 cleanup
 
 *Warning:* The `cleanup` command will remove the Helm v2 Configuration, Release Data and Tiller Deployment.
 It cleans up all releases managed by Helm v2. It will not be possible to restore them if you haven't made a backup of the releases.
-Helm v2 will not be usable afterwards.
+Helm v2 will not be usable afterwards. Cleanup should only be run once all migration (clusters and Tiller instances) for a Helm v2 client is complete.
 
 ## Install
 


### PR DESCRIPTION
Update the README with information when Helm client manages releases in multiple clusters with multiple Tiller instances. Also, added prerequisite section.