### PR TITLE
fix(*): update gopath to use github.com/helm convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Here are some suggestions to mitigate against potential risks during migration:
   3. Migrate [Helm v2 releases](#migrate-helm-v2-releases).
   4. When happy that Helm v3 is managing Helm v2 data as expected, then [clean up](#clean-up-helm-v2-data) Helm v2 data.
      *Note:*: Only use the plugin to do clean up. Using `helm`, `kubectl` or other tools could lead to data loss and an indeterminate
-      state for the release(s).  
+      state for the release(s).
 
 **Note:**
-A Helm v2 client: 
+A Helm v2 client:
 - can manage 1 to many Kubernetes clusters.
 - can connect to 1 to many Tiller instances for  a cluster.
- 
+
 This means that you have to cognisant of this when migrating as releases are deployed into clusters by Tiller and
 its namespace. You have to therefore be aware of migrating for each cluster and each Tiller instance that is managed
 by the Helm v2 client instance. [Clean up](#clean-up-helm-v2-data) should only be run once all migration for a Helm v2 client is complete.
@@ -87,7 +87,7 @@ Flags:
 It will migrate:
 - Chart starters
 - Repositories
-- Plugins 
+- Plugins
 
 **Note:**
 - The `move config` command will create the Helm v3 config and data folders if they don't exist, and will override the `repositories.yaml` file if it does exist.
@@ -160,7 +160,7 @@ It will clean:
 - v2 release data
 - Tiller deployment
 
-Clean up can be done individually also, by setting one or all of the following flags: `--config-cleanup`, `--release-cleanup` and `--tiller-cleanup`. 
+Clean up can be done individually also, by setting one or all of the following flags: `--config-cleanup`, `--release-cleanup` and `--tiller-cleanup`.
 If none of these flag are set, then all cleanup is performed.
 
 For cleanup it uses the default Helm v2 home folder.
@@ -189,10 +189,10 @@ Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "stable" chart repository
 Update Complete. ⎈Happy Helming!⎈
 Error: open /home/usr1/.cache/helm/repository/local-index.yaml: no such file or directory
-``` 
+```
 
-A. Local respoitories are not copied to Helm v3. You therefore need to remove all local repositories from Helm v3 using `<helm3> repo remove` and re-add where 
-required using `<helm3> repo add`. This is a necessary refresh to align references for Helm v3 and remove the conflict. It is worthwhile to also refresh the 
+A. Local respoitories are not copied to Helm v3. You therefore need to remove all local repositories from Helm v3 using `<helm3> repo remove` and re-add where
+required using `<helm3> repo add`. This is a necessary refresh to align references for Helm v3 and remove the conflict. It is worthwhile to also refresh the
 repository list afterwards: `<helm3> repo update`. You should then be able to run the chart dependency update command successfully.
 
 ## Developer (From Source) Install
@@ -202,6 +202,8 @@ If you would like to handle the build yourself, this is the recommended way to d
 You must first have [Go v1.13](http://golang.org) installed, and then you run:
 
 ```console
+$ mkdir -p ${GOPATH}/src/github.com/helm
+$ cd $_
 $ git clone git@github.com:helm/helm-2to3.git
 $ cd helm-2to3
 $ make build

--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"helm-2to3/pkg/common"
-	"helm-2to3/pkg/v2"
+	"github.com/helm/helm-2to3/pkg/common"
+	v2 "github.com/helm/helm-2to3/pkg/v2"
 )
 
 var (

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -22,11 +22,10 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
-
-	"helm-2to3/pkg/v2"
-	"helm-2to3/pkg/v3"
-
 	v2rel "k8s.io/helm/pkg/proto/hapi/release"
+
+	v2 "github.com/helm/helm-2to3/pkg/v2"
+	v3 "github.com/helm/helm-2to3/pkg/v3"
 )
 
 var (

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -16,9 +16,7 @@ limitations under the License.
 
 package cmd
 
-import (
-	"github.com/spf13/pflag"
-)
+import "github.com/spf13/pflag"
 
 type EnvSettings struct {
 	tillerNamespace  string

--- a/cmd/move_config.go
+++ b/cmd/move_config.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"helm-2to3/pkg/common"
+	"github.com/helm/helm-2to3/pkg/common"
 )
 
 func newMoveConfigCmd(out io.Writer) *cobra.Command {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module helm-2to3
+module github.com/helm/helm-2to3
 
 go 1.13
 

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ package main
 import (
 	"os"
 
-	"helm-2to3/cmd"
+	"github.com/helm/helm-2to3/cmd"
 )
 
 func main() {

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"helm-2to3/pkg/v2"
-	"helm-2to3/pkg/v3"
+	v2 "github.com/helm/helm-2to3/pkg/v2"
+	v3 "github.com/helm/helm-2to3/pkg/v3"
 )
 
 const sep = string(filepath.Separator)


### PR DESCRIPTION
The common convention with repositories on Github is `github.com/ORG/REPO`.

This way `go get github.com/helm/helm-2to3` will work.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>