### PR TITLE
fix(typo): Fix "configration" typos in command.

### DIFF
--- a/cmd/move_config.go
+++ b/cmd/move_config.go
@@ -64,9 +64,9 @@ func Move(dryRun bool) error {
 		log.Println()
 	}
 
-	log.Println("WARNING: Helm v3 configuration maybe overwritten during this operation.")
+	log.Println("WARNING: Helm v3 configuration may be overwritten during this operation.")
 	log.Println()
-	doCleanup, err := utils.AskConfirmation("Move Config", "move the v2 configration")
+	doCleanup, err := utils.AskConfirmation("Move Config", "move the v2 configuration")
 	if err != nil {
 		return err
 	}
@@ -75,13 +75,13 @@ func Move(dryRun bool) error {
 		return nil
 	}
 
-	log.Println("\nHelm v2 configuration will be moved to Helm v3 configration.")
+	log.Println("\nHelm v2 configuration will be moved to Helm v3 configuration.")
 	err = utils.Copyv2HomeTov3(dryRun)
 	if err != nil {
 		return err
 	}
 	if !dryRun {
-		log.Println("Helm v2 configuration was moved successfully to Helm v3 configration.")
+		log.Println("Helm v2 configuration was moved successfully to Helm v3 configuration.")
 	}
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?
Fixes a small typo ("configration" vs "configuration") that appears in the plugin command in a couple of places, e.g.:

```
λ helm 2to3 move config --dry-run
[...]
λ helm 2to3 move config --dry-run
[Move Config/confirm] Are you sure you want to move the v2 configration? [y/N]: y
                                                           # ^^
Helm v2 configuration will be moved to Helm v3 configration.
                                               # ^^
```

Thanks for the excellent tool, btw! Made migration a breeze. 👍