### PR TITLE
Provide a completion file for static completion

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,5 +15,6 @@ archive:
   files:
     - LICENSE
     - plugin.yaml
+    - completion.yaml
 checksum:
   name_template: 'checksums.txt'

--- a/completion.yaml
+++ b/completion.yaml
@@ -1,0 +1,31 @@
+commands:
+- name: cleanup
+  flags:
+  - config-cleanup
+  - dry-run
+  - l
+  - label
+  - release-cleanup
+  - s
+  - release-storage
+  - tiller-cleanup
+  - t
+  - tiller-ns
+  - tiller-out-cluster
+- name: convert
+  flags:
+  - delete-v2-releases
+  - dry-run
+  - l
+  - label
+  - s
+  - release-storage
+  - release-versions-max
+  - t
+  - tiller-ns
+  - tiller-out-cluster
+- name: move
+  commands:
+  - name: config
+    flags:
+    - dry-run

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "2to3"
-version: "0.3.1"
+version: "0.4.0"
 usage: "migrate and cleanup Helm v2 configuration and releases in-place to Helm v3"
 description: "migrate and cleanup Helm v2 configuration and releases in-place to Helm v3"
 command: "$HELM_PLUGIN_DIR/bin/2to3"

--- a/scripts/install_plugin.sh
+++ b/scripts/install_plugin.sh
@@ -37,3 +37,4 @@ fi
 tar xzf "releases/v${version}.tar.gz" -C "releases/v${version}"
 mv "releases/v${version}/2to3" "bin/2to3" || \
     mv "releases/v${version}/2to3.exe" "bin/2to3"
+mv "releases/v${version}/completion.yaml" .


### PR DESCRIPTION
Helm 3.2 will support completion for plugins.

This PR adds a `completion.yaml` file that will be processed by Helm 3.2 to provide completion for flags and subcmds.  It will not have any impact for previous versions of helm, so this can be included right away if approved.

With this PR users will be able to do things like:
```
$ helm 2to3 <TAB>
cleanup   convert   move
$ helm 2to3 convert --d
--debug    --delete-v2-releases     --dry-run
```