### PR TITLE
Updated owners with more recent maintainership

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,15 @@
 maintainers:
   - adamreese
   - bacongobbler
-  - fibonacci1729
   - hickeyma
   - jdolitsky
   - mattfarina
-  - michelleN
   - prydonius
   - rimusz
   - SlickNik
   - technosophos
-  - thomastaylor312
 emeritus:
+  - fibonacci1729
+  - michelleN
+  - thomastaylor312
   - viglesiasce


### PR DESCRIPTION
This updates various maintainers to emeritus:

- @michelleN 
- @thomastaylor312 
- @fibonacci1729 

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>