### PR TITLE
Moving prydonius to emeritus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,12 +4,12 @@ maintainers:
   - hickeyma
   - jdolitsky
   - mattfarina
-  - prydonius
   - rimusz
   - SlickNik
   - technosophos
 emeritus:
   - fibonacci1729
   - michelleN
+  - prydonius
   - thomastaylor312
   - viglesiasce


### PR DESCRIPTION
Thanks, @prydonius! Moving you to emeritus per @technosophos.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>