### PR TITLE
fix the developer guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,11 +269,9 @@ $ kubectl get configmap -n kube-system -l "OWNER=TILLER" \
 
 If you would like to handle the build yourself, this is the recommended way to do it.
 
-You must first have [Go v1.13](http://golang.org) installed, and then you run:
+You must first have [Go v1.17](http://golang.org) installed, and then you run:
 
 ```console
-$ mkdir -p ${GOPATH}/src/github.com/helm
-$ cd $_
 $ git clone git@github.com:helm/helm-2to3.git
 $ cd helm-2to3
 $ make build


### PR DESCRIPTION
fix the developer guide, then developer could follow the guide and build it locally

Includes changes as below:
1. Need Go v1.17
2. Do not need clone code into GOPATH anymore